### PR TITLE
Change SWISH_SHA1 to ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     cleancss node-requirejs
 
 ENV SWISH_HOME /swish
-ENV SWISH_SHA1 V1.7.0
+ARG SWISH_SHA1 V1.7.0
 
 RUN echo "At version ${SWISH_SHA1}"
 RUN git clone https://github.com/SWI-Prolog/swish.git && \


### PR DESCRIPTION
At the moment the only way to change version of swish used in the build is to edit the Docker file as `docker build` does not accept env variables.
This change allows to override swish version by supplying it to build via `--build-arg`
References
- [--build-arg](https://docs.docker.com/engine/reference/commandline/build/#build-arg)
- [ARG](https://docs.docker.com/engine/reference/builder/#arg)